### PR TITLE
Fix/mcp schema errors

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,24 +1,3 @@
 <!-- Use this file to provide workspace-specific custom instructions to Copilot. For more details, visit https://code.visualstudio.com/docs/copilot/copilot-customization#_use-a-githubcopilotinstructionsmd-file -->
 
-# Adobe Express MCP Server
 
-This is a Model Context Protocol (MCP) server implementation for integrating with Adobe Express. The project uses TypeScript and the MCP SDK.
-
-You can find more info and examples at https://modelcontextprotocol.io/llms-full.txt
-
-## Project Structure
-- `/src` - TypeScript source files
-  - `index.ts` - Main server entry point
-- `/dist` - Compiled JavaScript output
-
-## Helpful Resources
-- Adobe Express API documentation
-- Model Context Protocol SDK documentation
-- Design patterns for MCP server implementation
-
-## Coding Style Guidelines
-- Use ES modules
-- Prefer async/await for asynchronous operations
-- Document functions with JSDoc comments
-- Use strong typing with TypeScript
-- Follow semantic versioning for releases

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,5 +1,4 @@
 {
-  // Inputs are prompted on first server start, then stored securely by VS Code
   "inputs": [
     {
       "type": "promptString",
@@ -11,7 +10,10 @@
       "type": "pickString",
       "id": "knowledge-source-mode",
       "description": "Knowledge source mode for documentation",
-      "options": ["github", "local"],
+      "options": [
+        "github",
+        "local"
+      ],
       "default": "github"
     }
   ],
@@ -19,7 +21,9 @@
     "adobeExpressDev": {
       "type": "stdio",
       "command": "node",
-      "args": ["${workspaceFolder}/dist/src/index.js"],
+      "args": [
+        "/Users/geoffreynwachukwu/Documents/Sandgrouse/Products/Adobe Express/adobe-express-mcp-server/dist/src/index.js"
+      ],
       "env": {
         "MCP_GITHUB_PAT": "${input:github-pat}",
         "KNOWLEDGE_SOURCE_MODE": "${input:knowledge-source-mode}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adobe-express-mcp-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adobe-express-mcp-server",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.4",
@@ -17,12 +17,20 @@
         "marked": "^12.0.2",
         "zod": "^3.24.4"
       },
+      "bin": {
+        "express-mcp-help": "scripts/help.js",
+        "express-mcp-install": "scripts/install-in-vscode.js",
+        "express-mcp-workspace": "scripts/install-to-workspace.js"
+      },
       "devDependencies": {
         "@types/dotenv": "^6.1.1",
         "@types/fs-extra": "^11.0.4",
         "@types/marked": "^6.0.0",
         "@types/node": "^22.15.18",
         "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {

--- a/src/github_doc_service.ts
+++ b/src/github_doc_service.ts
@@ -147,10 +147,21 @@ function extractTagsFromPath(filePathWithinBase: string, dataSource: 'express_sd
   let tags = parts.slice(0, -1).concat(filename === 'index' ? [] : [filename]);
   
   if (dataSource === 'spectrum_web_components') {
-    if (filename === 'readme' && parts.length > 0 && parts[parts.length-1] !== 'packages') {
-      tags = [parts[parts.length-1]];
+    // For spectrum web components, the structure is packages/component-name/README.md
+    // We want to extract the component name as the primary tag
+    if (filename === 'readme' && parts.length >= 2 && parts[0] === 'packages') {
+      // For packages/tabs/README.md -> extract 'tabs'
+      tags = [parts[1]]; // The component name is the second part
     } else {
-      tags = parts.filter(p => p !== 'packages' && p !== 'stories' && p !== 'src' && p !== 'docs');
+      // For other files, filter out structural directories and extract meaningful parts
+      tags = parts.filter(p => p !== 'packages' && p !== 'stories' && p !== 'src' && p !== 'docs' && p !== 'test');
+      
+      // Add the component name (first part after packages) if not already included
+      if (parts.length >= 2 && parts[0] === 'packages' && !tags.includes(parts[1])) {
+        tags.unshift(parts[1]); // Add component name as first tag
+      }
+      
+      // Add filename if it's meaningful
       if (filename !== 'index' && filename !== 'readme' && !tags.includes(filename)) {
         tags.push(filename);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,38 @@ const MCPResultItemSchema = z.object({
   dataSource: z.enum(['express_sdk', 'spectrum_web_components', 'code_sample', 'unknown'])
 });
 
+const MCPResultItemJsonSchema = {
+  type: "object",
+  properties: {
+    type: { type: "string" },
+    title: { type: "string" },
+    content: { type: "string" },
+    raw_markdown_content: { type: "string" },
+    source_hint: { type: "string" },
+    tags: { type: "array", items: { type: "string" } },
+    language: { type: "string" },
+    frontmatter: { type: "object", additionalProperties: true },
+    parent_title: { type: "string" },
+    dataSource: { type: "string", enum: ['express_sdk', 'spectrum_web_components', 'code_sample', 'unknown'] }
+  },
+  required: ["type", "title", "content", "source_hint", "dataSource"]
+};
+
+// Make sure MCPResultItemJsonSchema is defined before this one.
+const QueryDocumentationOutputJsonSchema = {
+  type: "object",
+  properties: {
+    query_received: { type: "string" },
+    results: {
+      type: "array",
+      items: MCPResultItemJsonSchema // Embed the schema directly
+    },
+    confidence_score: { type: "number" },
+    mode_used: { type: "string", enum: ["github", "local"] }
+  },
+  required: ["query_received", "results"] // confidence_score and mode_used are optional
+};
+
 // --- TypeScript Interfaces ---
 interface QueryDocumentationOutput {
   query_received: string;
@@ -186,9 +218,13 @@ server.tool(
 
 // Create an output schema for setKnowledgeSource
 const SetKnowledgeSourceOutputSchema = {
-  status: { type: "string" },
-  message: { type: "string" },
-  new_mode: { type: "string", enum: ["github", "local"] }
+  type: "object",
+  properties: {
+    status: { type: "string" },
+    message: { type: "string" },
+    new_mode: { type: "string", enum: ["github", "local"] }
+  },
+  required: ["status", "message", "new_mode"]
 };
 
 server.tool(
@@ -231,7 +267,7 @@ server.tool(
   "queryDocumentation",
   "Query the Adobe Express SDK and Spectrum Web Components documentation.",
   QueryDocumentationInputSchema.shape, // Use Zod shape for input schema
-  QueryDocumentationOutputZodSchema.shape, // Use Zod shape for output schema
+  QueryDocumentationOutputJsonSchema, // Use Zod shape for output schema
   async (validatedPayload) => {
     const query_text = validatedPayload.query_text;
     const target_source_hint = validatedPayload.target_source;
@@ -427,9 +463,13 @@ const ImplementFeatureInputSchema = z.object({
 // Register Adobe Express Add-on Developer Tools
 // Create an output schema for scaffold-addon-project
 const ScaffoldAddonOutputSchema = {
-  projectType: { type: "string" },
-  projectName: { type: "string" },
-  description: { type: "string" }
+  type: "object",
+  properties: {
+    projectType: { type: "string" },
+    projectName: { type: "string" },
+    description: { type: "string" }
+  },
+  required: ["projectType", "projectName", "description"]
 };
 
 server.tool(

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,15 @@ const SetKnowledgeSourceInputSchema = z.object({
   mode: z.enum(['github', 'local']),
 });
 
+const AssistantCapabilitiesOutputZodSchema = z.object({
+  agent_name: z.string(),
+  description: z.string(),
+  supported_query_keywords: z.array(z.string()).optional(),
+  documentation_source: z.string(),
+  current_knowledge_mode: z.enum(['github', 'local']),
+  available_knowledge_modes: z.array(z.enum(['github', 'local']))
+});
+
 // Define MCPResultItemSchema for proper validation
 const MCPResultItemSchema = z.object({
   type: z.string(),
@@ -181,12 +190,12 @@ const AssistantCapabilitiesOutputJsonSchema = {
 };
 
 console.error("Attempting to register getAssistantCapabilities. Output schema being used:");
-console.error("AssistantCapabilitiesOutputJsonSchema:", JSON.stringify(AssistantCapabilitiesOutputJsonSchema, null, 2));
+console.error("AssistantCapabilitiesOutputZodSchema.shape:", JSON.stringify(AssistantCapabilitiesOutputZodSchema.shape, null, 2));
 server.tool(
   "getAssistantCapabilities",
   "Get the current capabilities, status, and configuration of the Adobe Express & Spectrum Assistant.",
   {}, // Empty object for params
-  AssistantCapabilitiesOutputJsonSchema, // Use wrapped JSON schema for output
+  AssistantCapabilitiesOutputZodSchema.shape, // Use wrapped JSON schema for output
   async (_args, _extra) => {
     const allTags = new Set<string>();
     if (currentKnowledgeMode === 'local' && LOCAL_KNOWLEDGE_BASE.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,6 +180,8 @@ const AssistantCapabilitiesOutputJsonSchema = {
   required: ["agent_name", "description", "documentation_source", "current_knowledge_mode", "available_knowledge_modes"]
 };
 
+console.error("Attempting to register getAssistantCapabilities. Output schema being used:");
+console.error("AssistantCapabilitiesOutputJsonSchema:", JSON.stringify(AssistantCapabilitiesOutputJsonSchema, null, 2));
 server.tool(
   "getAssistantCapabilities",
   "Get the current capabilities, status, and configuration of the Adobe Express & Spectrum Assistant.",
@@ -211,16 +213,19 @@ server.tool(
       available_knowledge_modes: availableKnowledgeModes,
     };
     
-    // Return in MCP-compatible format
-    return {
-      structuredContent: {
+    const structuredContentForReturn = {
         agent_name: capabilities.agent_name,
         description: capabilities.description,
         supported_query_keywords: capabilities.supported_query_keywords,
         documentation_source: capabilities.documentation_source,
         current_knowledge_mode: capabilities.current_knowledge_mode,
         available_knowledge_modes: capabilities.available_knowledge_modes
-      },
+    };
+    console.error("getAssistantCapabilities handler - structuredContent being returned:", JSON.stringify(structuredContentForReturn, null, 2));
+
+    // Return in MCP-compatible format
+    return {
+      structuredContent: structuredContentForReturn,
       content: [
         {
           type: "text",


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the MCP server, focusing on schema validation, tool registration, and tag extraction logic. The changes enhance the robustness and maintainability of the server by enforcing stricter schema validation, improving the extraction of tags from documentation paths, and updating the way tools are registered and logged.

### Schema validation and tool registration improvements

* Refactored tool registration from `server.tool` to `server.registerTool` for both `getAssistantCapabilities` and `queryDocumentation`, using Zod schemas for input and output validation and adding detailed logging for schema and returned structured content. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L136-R200) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L229-R296)
* Added and enforced JSON schema definitions for tool outputs, including `AssistantCapabilitiesOutputJsonSchema`, `QueryDocumentationOutputJsonSchema`, `SetKnowledgeSourceOutputSchema`, and `ScaffoldAddonOutputSchema`, ensuring required fields are specified. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R96-R142) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R244-R250) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R502-R508)
* Updated the return values of tool handlers to match the newly enforced output schemas, ensuring MCP compatibility and consistent structure. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L156-R216) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R227-R235) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R421-R438)

### Tag extraction logic enhancements

* Improved the `extractTagsFromPath` function in `src/github_doc_service.ts` to more accurately extract component tags from Spectrum Web Components documentation paths, handling various directory structures and ensuring meaningful tags are selected.

### Configuration and documentation updates

* Updated `.vscode/mcp.json` to specify absolute paths for the server command and expanded options for the knowledge source mode. [[1]](diffhunk://#diff-756c99ad6a15758981c15d6ba32a2d83391908e8e021f0399e9d34339dc4eadaL2) [[2]](diffhunk://#diff-756c99ad6a15758981c15d6ba32a2d83391908e8e021f0399e9d34339dc4eadaL14-R26)
* Removed outdated and redundant project documentation from `.github/copilot-instructions.md` to declutter workspace instructions.