### PR TITLE
refactor: Rename project to community-express-dev-mcp and update rela…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Adobe Express MCP Server
+# Community MCP Server for Adobe Express Add-on Developers
 
 This is a Model Context Protocol (MCP) server designed for Adobe Express Add-on developers. It provides developer-focused tools to assist with building Adobe Express add-ons and integrating with Adobe Express SDK.
 
@@ -24,7 +24,7 @@ You can install the Adobe Express MCP Server in several ways:
 
 ```bash
 # Install globally
-npm install -g adobe-express-mcp-server
+npm install -g community-express-dev-mcp
 
 # Run the VS Code installation script
 express-mcp-install
@@ -34,8 +34,8 @@ express-mcp-install
 
 ```bash
 # Clone the repository
-git clone https://github.com/Sandgrouse/adobe-express-mcp-server.git
-cd Adobe-Express-MCP-server
+git clone https://github.com/EnventDigital/community-express-dev-mcp.git
+cd community-express-dev-mcp
 
 # Install dependencies
 npm install
@@ -58,7 +58,7 @@ express-mcp-workspace
 
 # If installed from GitHub:
 cd /path/to/your/project
-/path/to/Adobe-Express-MCP-server/scripts/install-to-workspace.js
+/path/to/community-express-dev-mcp/scripts/install-to-workspace.js
 ```
 
 This will create a `.vscode/mcp.json` file in your project that configures the Adobe Express MCP server for that workspace.
@@ -142,7 +142,7 @@ To use this MCP server with Claude for Desktop:
     "adobe-express": {
       "command": "node",
       "args": [
-        "/ABSOLUTE/PATH/TO/Adobe-Express-MCP-server/dist/index.js"
+        "/ABSOLUTE/PATH/TO/community-express-dev-mcp/dist/index.js"
       ]
     }
   }
@@ -152,7 +152,7 @@ To use this MCP server with Claude for Desktop:
 4. Replace `/ABSOLUTE/PATH/TO/` with the actual path to your project.
    For example:
    ```
-   "/Users/username/Documents/Adobe-Express-MCP-server/dist/index.js"
+   "/Users/username/Documents/community-express-dev-mcp/dist/index.js"
    ```
    
 5. Save the file and restart Claude for Desktop
@@ -236,10 +236,10 @@ The Adobe Express MCP Server is available as an npm package that you can install
 
 ```bash
 # Install globally
-npm install -g adobe-express-mcp-server
+npm install -g community-express-dev-mcp
 
 # Or install as a dev dependency in your project
-npm install --save-dev adobe-express-mcp-server
+npm install --save-dev community-express-dev-mcp
 ```
 
 After installation, you can use the following commands:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "adobe-express-mcp-server",
+  "name": "community-express-dev-mcp",
   "version": "1.0.1",
-  "description": "Adobe Express MCP server for integrating with LLMs",
+  "description": "Adobe Express add-on developer MCP server for integrating with LLMs",
   "type": "module",
   "main": "dist/src/index.js",
   "bin": {
@@ -34,12 +34,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Sandgrouse/adobe-express-mcp-server.git"
+    "url": "git+https://github.com/Sandgrouse/community-express-dev-mcp.git"
   },
   "bugs": {
-    "url": "https://github.com/Sandgrouse/adobe-express-mcp-server/issues"
+    "url": "https://github.com/Sandgrouse/community-express-dev-mcp/issues"
   },
-  "homepage": "https://github.com/Sandgrouse/adobe-express-mcp-server#readme",
+  "homepage": "https://github.com/Sandgrouse/community-express-dev-mcp#readme",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/scripts/help.js
+++ b/scripts/help.js
@@ -19,6 +19,6 @@ console.log('\n3. express-mcp-help');
 console.log('   Displays this help message');
 console.log('   Usage: express-mcp-help');
 console.log('\nFor more information, visit:');
-console.log('https://github.com/Sandgrouse/adobe-express-mcp-server');
+console.log('https://github.com/Sandgrouse/community-express-dev-mcp');
 console.log('='.repeat(80));
 console.log('\n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,7 @@ interface AssistantCapabilitiesOutput {
 
 // Create server instance
 const serverInfo = {
-  name: "adobe-express-developer-assistant",
+  name: "community-express-developer-mcp",
   version: "1.0.0",
   description: "Developer assistant for Adobe Express Add-on and Spectrum Web Components development"
 };


### PR DESCRIPTION
This pull request updates the project to rebrand it from "Adobe Express MCP Server" to "Community MCP Server for Adobe Express Add-on Developers". The changes affect documentation, package metadata, repository links, and code identifiers to reflect the new name and repository location.

**Project Renaming and Branding**

* Updated the project name and description in `README.md` and `package.json` from `adobe-express-mcp-server` to `community-express-dev-mcp`, including installation instructions, repository links, and usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R27) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R38) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-R61) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L145-R145) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L155-R155) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L239-R242) [[8]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R4)
* Changed repository and issue tracker URLs in `package.json` and help output to point to the new GitHub repository for `community-express-dev-mcp`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L37-R42) [[2]](diffhunk://#diff-d56aadf1ef3a66148e4b744a043a2716e2fea5b99b708c8e4ba14acf0c5e7bcbL22-R22)

**Code and Identifier Updates**

* Updated the server name in `src/index.ts` from `adobe-express-developer-assistant` to `community-express-developer-mcp` to match the new branding.…ted documentation